### PR TITLE
Bug fix: fix check for normalized variant

### DIFF
--- a/src/c++/lib/htsapi/vcf_record.cpp
+++ b/src/c++/lib/htsapi/vcf_record.cpp
@@ -158,8 +158,10 @@ is_normalized() const
 
         if (alt_length != ref_length)
         {
-            // this checks that indels are reference-padded
-            if ( (*alt_allele.begin()) == (*ref.begin()))
+            // this checks that indels are reference-padded.  Do not check when there is one
+            // anchor base in the reference allele , or if there is only one base in the alternate
+            // allele.
+            if ((*alt_allele.begin()) == (*ref.begin()) && ref_length > 1 && alt_length > 1)
             {
                 // this checks that they're left-shifted
                 for (unsigned i = ref_length - 1, j = alt_length - 1; ; ++i, ++j)


### PR DESCRIPTION
This variant is normalized (confirmed by running `vt`) but wrongly reported as not normalized when running with `--forceGT` and supplying the known VCF (in this case dbsnp).

```
chr22   16647586        rs144514652     G       GATTCCCTG,GATTCCCTGTCTTCTCTCCCC .       .       RS=144514652;RSPOS=16647586;dbSNPBuildID=134;SSR=0;SAO=0;VP=0x05000008000517002e000200;GENEINFO=TPTEP1:387590;WGT=1;VC=DIV;INT;ASP;VLD;G5A;G5;KGPhase3;CAF=0.3492,.,0.6508;COMMON=1;TOPMED=0.52381179918450560,.,0.47611652650356778
```