### PR TITLE
Update quickStart.md

### DIFF
--- a/docs/userGuide/quickStart.md
+++ b/docs/userGuide/quickStart.md
@@ -15,7 +15,7 @@ the demo on the strelka 2.9.2 binary distribution could be accomplished as follo
 # download strelka binary
 wget https://github.com/Illumina/strelka/releases/download/v2.9.2/strelka-2.9.2.centos6_x86_64.tar.bz2
 # decompress
-tar xvjf strelka-2.9.2.centos6_x86_64.tar.bz2
+tar xvf strelka-2.9.2.centos6_x86_64.tar.bz2
 # run demo to check successful installation
 bash strelka-2.9.2.centos6_x86_64/bin/runStrelkaSomaticWorkflowDemo.bash
 bash strelka-2.9.2.centos6_x86_64/bin/runStrelkaGermlineWorkflowDemo.bash


### PR DESCRIPTION
Don't think the -j option is needed here. From the tar manual:

"-j, --bzip, --bzip2, --bunzip2
             (c mode only) Compress the resulting archive with bzip2(1).  In extract or list modes, this option is ignored.  Note that,
             unlike other tar implementations, this implementation recognizes bzip2 compression automatically when reading archives."