### PR TITLE
Add <limits> headers for gcc-12

### DIFF
--- a/src/c++/lib/calibration/IndelErrorModel.hh
+++ b/src/c++/lib/calibration/IndelErrorModel.hh
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include "IndelErrorRateSet.hh"
 
 #include "starling_common/AlleleReportInfo.hh"


### PR DESCRIPTION
gcc-12 cleaned up headers dependencies a bit and exposed
missing header inclusion:

    src/c++/lib/calibration/IndelErrorModel.hh:100:33: error: 'numeric_limits' is not a member of 'std'
      100 |     double logErrorRate = -std::numeric_limits<double>::infinity();
          |                                 ^~~~~~~~~~~~~~